### PR TITLE
Return concrete `Iterator` types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["vec", "map", "set"]
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
-rand = "0.7"
+rand = "0.8"
 serde_json = "1.0"
 
 [features]

--- a/src/map.rs
+++ b/src/map.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use core::{
     borrow::Borrow,
     fmt::{self, Debug},
+    slice::{Iter, IterMut},
 };
 
 /// `map_vec::Map` is a data structure with a [`HashMap`](https://doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html)-like API but based on a `Vec`.
@@ -117,14 +118,12 @@ impl<K: Eq, V> Map<K, V> {
         self.backing.is_empty()
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> + DoubleEndedIterator + ExactSizeIterator {
-        self.backing.iter().map(|(k, v)| (k, v))
+    pub fn iter(&self) -> Iter<(K, V)> {
+        self.backing.iter()
     }
 
-    pub fn iter_mut(
-        &mut self,
-    ) -> impl Iterator<Item = (&mut K, &mut V)> + DoubleEndedIterator + ExactSizeIterator {
-        self.backing.iter_mut().map(|(k, v)| (k, v))
+    pub fn iter_mut(&mut self) -> IterMut<(K, V)> {
+        self.backing.iter_mut()
     }
 
     pub fn keys(&self) -> impl Iterator<Item = &K> + DoubleEndedIterator + ExactSizeIterator {

--- a/src/map.rs
+++ b/src/map.rs
@@ -18,9 +18,17 @@ use core::{
 /// map.entry("hello".to_string()).and_modify(|mut v| v.push_str("!"));
 /// assert_eq!(map.get("hello").map(String::as_str), Some("world!"))
 /// ```
-#[derive(Clone, Default, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Map<K, V> {
     backing: Vec<(K, V)>,
+}
+
+impl<K, V> Default for Map<K, V> {
+    fn default() -> Self {
+        Self {
+            backing: Vec::default(),
+        }
+    }
 }
 
 impl<K: Eq, V> Map<K, V> {
@@ -1277,5 +1285,15 @@ mod test_map {
 
         a.insert("b", 2);
         assert_eq!(r#"{"a": 1, "b": 2}"#, format!("{:?}", a));
+    }
+
+    /// Ensures that, like `Vec`, `Default` works for `Map` even when its
+    /// key/value types do not implement `Default`.
+    #[test]
+    fn test_default() {
+        struct NoDefault;
+
+        let _: Vec<NoDefault> = Default::default();
+        let _: Map<NoDefault, NoDefault> = Default::default();
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use core::{
     borrow::Borrow,
     fmt::{self, Debug},
+    iter::FusedIterator,
     slice::{Iter, IterMut},
 };
 
@@ -126,7 +127,9 @@ impl<K: Eq, V> Map<K, V> {
         self.backing.iter_mut()
     }
 
-    pub fn keys(&self) -> impl Iterator<Item = &K> + DoubleEndedIterator + ExactSizeIterator {
+    pub fn keys(
+        &self,
+    ) -> impl Iterator<Item = &K> + DoubleEndedIterator + ExactSizeIterator + FusedIterator {
         self.backing.iter().map(|(k, _)| k)
     }
 
@@ -177,13 +180,16 @@ impl<K: Eq, V> Map<K, V> {
         self.backing.shrink_to_fit();
     }
 
-    pub fn values(&self) -> impl Iterator<Item = &V> + DoubleEndedIterator + ExactSizeIterator {
+    pub fn values(
+        &self,
+    ) -> impl Iterator<Item = &V> + DoubleEndedIterator + ExactSizeIterator + FusedIterator {
         self.backing.iter().map(|(_, v)| v)
     }
 
     pub fn values_mut(
         &mut self,
-    ) -> impl Iterator<Item = &mut V> + DoubleEndedIterator + ExactSizeIterator {
+    ) -> impl Iterator<Item = &mut V> + DoubleEndedIterator + ExactSizeIterator + FusedIterator
+    {
         self.backing.iter_mut().map(|(_, v)| v)
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -3,7 +3,6 @@ use core::{
     borrow::Borrow,
     fmt::{self, Debug},
     iter::FusedIterator,
-    slice::{Iter, IterMut},
 };
 
 /// `map_vec::Map` is a data structure with a [`HashMap`](https://doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html)-like API but based on a `Vec`.
@@ -127,18 +126,20 @@ impl<K: Eq, V> Map<K, V> {
         self.backing.is_empty()
     }
 
-    pub fn iter(&self) -> Iter<(K, V)> {
-        self.backing.iter()
+    pub fn iter(&self) -> Iter<'_, K, V> {
+        Iter {
+            iter: self.backing.iter(),
+        }
     }
 
-    pub fn iter_mut(&mut self) -> IterMut<(K, V)> {
-        self.backing.iter_mut()
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
+        IterMut {
+            iter: self.backing.iter_mut(),
+        }
     }
 
-    pub fn keys(
-        &self,
-    ) -> impl Iterator<Item = &K> + DoubleEndedIterator + ExactSizeIterator + FusedIterator {
-        self.backing.iter().map(|(k, _)| k)
+    pub fn keys(&self) -> Keys<'_, K, V> {
+        Keys { iter: self.iter() }
     }
 
     pub fn len(&self) -> usize {
@@ -188,17 +189,14 @@ impl<K: Eq, V> Map<K, V> {
         self.backing.shrink_to_fit();
     }
 
-    pub fn values(
-        &self,
-    ) -> impl Iterator<Item = &V> + DoubleEndedIterator + ExactSizeIterator + FusedIterator {
-        self.backing.iter().map(|(_, v)| v)
+    pub fn values(&self) -> Values<'_, K, V> {
+        Values { iter: self.iter() }
     }
 
-    pub fn values_mut(
-        &mut self,
-    ) -> impl Iterator<Item = &mut V> + DoubleEndedIterator + ExactSizeIterator + FusedIterator
-    {
-        self.backing.iter_mut().map(|(_, v)| v)
+    pub fn values_mut(&mut self) -> ValuesMut<'_, K, V> {
+        ValuesMut {
+            iter: self.iter_mut(),
+        }
     }
 }
 
@@ -224,25 +222,25 @@ impl<K: Debug, V: Debug> fmt::Debug for Map<K, V> {
     }
 }
 
-type MapRefIntoTuple<'a, K, V, I> = core::iter::Map<I, fn(&'a (K, V)) -> (&'a K, &'a V)>;
-type MapMutRefIntoTuple<'a, K, V, I> =
-    core::iter::Map<I, fn(&'a mut (K, V)) -> (&'a mut K, &'a mut V)>;
-
 impl<'a, K, V> IntoIterator for &'a Map<K, V> {
     type Item = (&'a K, &'a V);
-    type IntoIter = MapRefIntoTuple<'a, K, V, core::slice::Iter<'a, (K, V)>>;
+    type IntoIter = Iter<'a, K, V>;
 
     fn into_iter(self) -> <Self as IntoIterator>::IntoIter {
-        self.backing.iter().map(|(k, v)| (k, v))
+        Iter {
+            iter: self.backing.iter(),
+        }
     }
 }
 
 impl<'a, K, V> IntoIterator for &'a mut Map<K, V> {
     type Item = (&'a mut K, &'a mut V);
-    type IntoIter = MapMutRefIntoTuple<'a, K, V, core::slice::IterMut<'a, (K, V)>>;
+    type IntoIter = IterMut<'a, K, V>;
 
     fn into_iter(self) -> <Self as IntoIterator>::IntoIter {
-        self.backing.iter_mut().map(|(k, v)| (k, v))
+        IterMut {
+            iter: self.backing.iter_mut(),
+        }
     }
 }
 
@@ -315,6 +313,181 @@ impl<Q: Eq + ?Sized, K: Eq + Borrow<Q>, V> core::ops::Index<&Q> for Map<K, V> {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct Keys<'a, K, V> {
+    iter: Iter<'a, K, V>,
+}
+
+impl<K, V> Keys<'_, K, V> {
+    fn map_item<'a>(item: (&'a K, &'a V)) -> &'a K {
+        item.0
+    }
+}
+
+impl<'a, K, V> Iterator for Keys<'a, K, V> {
+    type Item = &'a K;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(Self::map_item)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<K, V> DoubleEndedIterator for Keys<'_, K, V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(Self::map_item)
+    }
+}
+
+impl<K, V> ExactSizeIterator for Keys<'_, K, V> {}
+impl<K, V> FusedIterator for Keys<'_, K, V> {}
+
+#[cfg(feature = "nightly")]
+impl<K, V> core::iter::TrustedLen for Keys<'_, K, V> {}
+
+#[derive(Debug, Clone)]
+pub struct Values<'a, K, V> {
+    iter: Iter<'a, K, V>,
+}
+
+impl<K, V> Values<'_, K, V> {
+    fn map_item<'a>(item: (&'a K, &'a V)) -> &'a V {
+        item.1
+    }
+}
+
+impl<'a, K, V> Iterator for Values<'a, K, V> {
+    type Item = &'a V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(Self::map_item)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<K, V> DoubleEndedIterator for Values<'_, K, V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(Self::map_item)
+    }
+}
+
+impl<K, V> ExactSizeIterator for Values<'_, K, V> {}
+impl<K, V> FusedIterator for Values<'_, K, V> {}
+
+#[cfg(feature = "nightly")]
+impl<K, V> core::iter::TrustedLen for Values<'_, K, V> {}
+
+#[derive(Debug)]
+pub struct ValuesMut<'a, K, V> {
+    iter: IterMut<'a, K, V>,
+}
+
+impl<K, V> ValuesMut<'_, K, V> {
+    fn map_item<'a>(item: (&'a mut K, &'a mut V)) -> &'a mut V {
+        item.1
+    }
+}
+
+impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
+    type Item = &'a mut V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(Self::map_item)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<K, V> DoubleEndedIterator for ValuesMut<'_, K, V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(Self::map_item)
+    }
+}
+
+impl<K, V> ExactSizeIterator for ValuesMut<'_, K, V> {}
+impl<K, V> FusedIterator for ValuesMut<'_, K, V> {}
+
+#[cfg(feature = "nightly")]
+impl<K, V> core::iter::TrustedLen for ValuesMut<'_, K, V> {}
+
+#[derive(Debug, Clone)]
+pub struct Iter<'a, K, V> {
+    iter: core::slice::Iter<'a, (K, V)>,
+}
+
+impl<'a, K, V> Iter<'a, K, V> {
+    fn map_item(item: &'a (K, V)) -> (&'a K, &'a V) {
+        (&item.0, &item.1)
+    }
+}
+
+impl<'a, K, V> Iterator for Iter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(Self::map_item)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<'a, K, V> DoubleEndedIterator for Iter<'a, K, V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(Self::map_item)
+    }
+}
+
+impl<'a, K, V> ExactSizeIterator for Iter<'a, K, V> {}
+impl<'a, K, V> FusedIterator for Iter<'a, K, V> {}
+
+#[cfg(feature = "nightly")]
+impl<'a, K, V> core::iter::TrustedLen for Iter<'a, K, V> {}
+
+#[derive(Debug)]
+pub struct IterMut<'a, K, V> {
+    iter: core::slice::IterMut<'a, (K, V)>,
+}
+
+impl<'a, K, V> IterMut<'a, K, V> {
+    fn map_item(item: &'a mut (K, V)) -> (&'a mut K, &'a mut V) {
+        (&mut item.0, &mut item.1)
+    }
+}
+
+impl<'a, K, V> Iterator for IterMut<'a, K, V> {
+    type Item = (&'a mut K, &'a mut V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(Self::map_item)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<'a, K, V> DoubleEndedIterator for IterMut<'a, K, V> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(Self::map_item)
+    }
+}
+
+impl<'a, K, V> ExactSizeIterator for IterMut<'a, K, V> {}
+impl<'a, K, V> FusedIterator for IterMut<'a, K, V> {}
+
+#[cfg(feature = "nightly")]
+impl<'a, K, V> core::iter::TrustedLen for IterMut<'a, K, V> {}
+
 pub enum Entry<'a, K: 'a, V: 'a> {
     Occupied(OccupiedEntry<'a, K, V>),
     Vacant(VacantEntry<'a, K, V>),
@@ -352,6 +525,7 @@ impl<'a, K, V> Entry<'a, K, V> {
 
 impl<'a, K: 'a, V: Default> Entry<'a, K, V> {
     pub fn or_default(self) -> &'a mut V {
+        #[allow(clippy::unwrap_or_default)]
         self.or_insert(Default::default())
     }
 }
@@ -1063,6 +1237,17 @@ mod test_map {
     }
 
     #[test]
+    fn test_double_ended() {
+        let xs = [(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)];
+
+        let map: Map<_, _> = xs.iter().cloned().collect();
+
+        let last = map.iter().next_back();
+
+        assert_eq!(last, xs.last().map(|item| (&item.0, &item.1)));
+    }
+
+    #[test]
     fn test_mut_size_hint() {
         let xs = [(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)];
 
@@ -1086,6 +1271,17 @@ mod test_map {
         for _ in iter.by_ref().take(3) {}
 
         assert_eq!(iter.len(), 3);
+    }
+
+    #[test]
+    fn test_mut_double_ended() {
+        let mut xs = [(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)];
+
+        let mut map: Map<_, _> = xs.iter().cloned().collect();
+
+        let last = map.iter_mut().next_back();
+
+        assert_eq!(last, xs.last_mut().map(|item| (&mut item.0, &mut item.1)));
     }
 
     #[test]

--- a/src/map.rs
+++ b/src/map.rs
@@ -60,7 +60,7 @@ impl<K: Eq, V> Map<K, V> {
                 entry_pos: pos,
                 // entry: unsafe { core::mem::transmute::<&mut (K, V), &'a mut (K, V)>(entry) },
                 /* ^ since the only operations on an OccupiedEntry modify `v` in-place, the Vec will
-                 * never move in memory (reallocte), so the ref is valid for the duration of the OE. */
+                 * never move in memory (reallocate), so the ref is valid for the duration of the OE. */
                 backing: &mut self.backing,
             }),
             None => Entry::Vacant(VacantEntry {
@@ -206,7 +206,7 @@ impl<K: Eq, V> Map<K, V> {
 impl<K: Debug, V: Debug> fmt::Debug for Map<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_map()
-            .entries(self.backing.iter().map(|&(ref k, ref v)| (k, v)))
+            .entries(self.backing.iter().map(|(ref k, ref v)| (k, v)))
             .finish()
     }
 }
@@ -792,7 +792,7 @@ mod test_map {
         let mut m = Map::new();
         assert!(m.insert(1, 2).is_none());
         assert_eq!(*m.get(&1).unwrap(), 2);
-        assert!(!m.insert(1, 3).is_none());
+        assert!(m.insert(1, 3).is_some());
         assert_eq!(*m.get(&1).unwrap(), 3);
     }
 
@@ -893,7 +893,7 @@ mod test_map {
         let vec = vec![(1, 1), (2, 2), (3, 3)];
         let mut map: Map<_, _> = vec.into_iter().collect();
         for value in map.values_mut() {
-            *value = (*value) * 2
+            *value *= 2
         }
         let values: Vec<_> = map.values().cloned().collect();
         assert_eq!(values.len(), 3);
@@ -1067,7 +1067,7 @@ mod test_map {
         map.insert(2, 1);
         map.insert(3, 4);
 
-        map[&4];
+        _ = map[&4];
     }
 
     #[test]
@@ -1135,12 +1135,12 @@ mod test_map {
 
         // Populate the map with some items.
         for _ in 0..50 {
-            let x = rng.gen_range(-10, 10);
+            let x = rng.gen_range(-10..10);
             m.insert(x, ());
         }
 
         for _ in 0..1000 {
-            let x = rng.gen_range(-10, 10);
+            let x = rng.gen_range(-10..10);
             match m.entry(x) {
                 Vacant(_) => {}
                 Occupied(e) => {
@@ -1199,11 +1199,11 @@ mod test_map {
         let key = "hello there";
         let value = "value goes here";
         assert!(a.is_empty());
-        a.insert(key.clone(), value.clone());
+        a.insert(key, value);
         assert_eq!(a.len(), 1);
         assert_eq!(a[key], value);
 
-        match a.entry(key.clone()) {
+        match a.entry(key) {
             Vacant(_) => panic!(),
             Occupied(e) => assert_eq!(key, *e.key()),
         }
@@ -1218,11 +1218,11 @@ mod test_map {
         let value = "value goes here";
 
         assert!(a.is_empty());
-        match a.entry(key.clone()) {
+        match a.entry(key) {
             Occupied(_) => panic!(),
             Vacant(e) => {
                 assert_eq!(key, *e.key());
-                e.insert(value.clone());
+                e.insert(value);
             }
         }
         assert_eq!(a.len(), 1);
@@ -1260,5 +1260,17 @@ mod test_map {
         } else {
             panic!("usize::MAX / 8 should trigger an OOM!")
         }
+    }
+
+    #[test]
+    fn test_debug_format() {
+        let mut a = Map::<&str, usize>::default();
+        assert_eq!("{}", format!("{:?}", a));
+
+        a.insert("a", 1);
+        assert_eq!(r#"{"a": 1}"#, format!("{:?}", a));
+
+        a.insert("b", 2);
+        assert_eq!(r#"{"a": 1, "b": 2}"#, format!("{:?}", a));
     }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use core::{
     borrow::Borrow,
     fmt::{self, Debug},
+    iter::FusedIterator,
     slice::Iter,
 };
 
@@ -61,7 +62,7 @@ impl<T: Eq> Set<T> {
     pub fn difference<'a>(
         &'a self,
         other: &'a Self,
-    ) -> impl Iterator<Item = &'a T> + DoubleEndedIterator {
+    ) -> impl Iterator<Item = &'a T> + DoubleEndedIterator + FusedIterator {
         self.backing.iter().filter(move |v| !other.contains(v))
     }
 
@@ -114,7 +115,7 @@ impl<T: Eq> Set<T> {
     pub fn intersection<'a>(
         &'a self,
         other: &'a Self,
-    ) -> impl Iterator<Item = &'a T> + DoubleEndedIterator<Item = &'a T> {
+    ) -> impl Iterator<Item = &'a T> + DoubleEndedIterator<Item = &'a T> + FusedIterator {
         self.backing.iter().filter(move |v| other.contains(v))
     }
 
@@ -175,7 +176,7 @@ impl<T: Eq> Set<T> {
     pub fn symmetric_difference<'a>(
         &'a self,
         other: &'a Self,
-    ) -> impl Iterator<Item = &'a T> + DoubleEndedIterator {
+    ) -> impl Iterator<Item = &'a T> + DoubleEndedIterator + FusedIterator {
         self.difference(other).chain(other.difference(self))
     }
 
@@ -193,7 +194,7 @@ impl<T: Eq> Set<T> {
     pub fn union<'a>(
         &'a self,
         other: &'a Self,
-    ) -> impl Iterator<Item = &'a T> + DoubleEndedIterator {
+    ) -> impl Iterator<Item = &'a T> + DoubleEndedIterator + FusedIterator {
         self.iter().chain(other.difference(self))
     }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use core::{
     borrow::Borrow,
     fmt::{self, Debug},
+    slice::Iter,
 };
 
 /// `map_vec::Set` is a data structure with a [`Set`](https://doc.rust-lang.org/std/collections/hash_set/struct.HashSet.html)-like API but based on a `Vec`.
@@ -133,7 +134,7 @@ impl<T: Eq> Set<T> {
         other.is_subset(self)
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &T> + DoubleEndedIterator + ExactSizeIterator {
+    pub fn iter(&self) -> Iter<T> {
         self.backing.iter()
     }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -269,6 +269,14 @@ impl<'a, T: 'a + Copy + Eq> Extend<&'a T> for Set<T> {
     }
 }
 
+impl<V, T: Into<Vec<V>>> From<T> for Set<V> {
+    fn from(values: T) -> Self {
+        Self {
+            backing: values.into(),
+        }
+    }
+}
+
 impl<T: Clone + Eq> core::ops::BitOr<&Set<T>> for &Set<T> {
     type Output = Set<T>;
     fn bitor(self, rhs: &Set<T>) -> Set<T> {
@@ -709,5 +717,19 @@ mod test_set {
 
         let _: Vec<NoDefault> = Default::default();
         let _: Set<NoDefault> = Default::default();
+    }
+
+    /// Ensures that things that can be turned `Into` a `Vec` can also be turned into a `Set`
+    #[test]
+    fn test_from_into_vec() {
+        #[allow(clippy::useless_conversion)]
+        let _: Vec<()> = vec![()].into();
+        let _: Set<()> = vec![()].into();
+        let _: Vec<()> = [()].into();
+        let _: Set<()> = [()].into();
+
+        let expected: Set<char> = ['a', 'b'].iter().copied().collect();
+        let actual: Set<char> = ['a', 'b', 'a'].into();
+        assert_eq!(expected, actual, "Values should be de-duped");
     }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -247,8 +247,26 @@ impl<T> IntoIterator for Set<T> {
 
 impl<T: Eq> core::iter::FromIterator<T> for Set<T> {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        let mut this = Self::new();
+        let iter = iter.into_iter();
+
+        let mut this = match iter.size_hint() {
+            (min, Some(max)) if min > 0 && min == max => {
+                // Exact size is known. Reserve the space.
+                Self::with_capacity(min)
+            }
+            (min, Some(_)) | (min, None) if min > 0 => {
+                // The exact size is not known, but there's a minimum size known.
+                // We'll reserve what we know.
+                Self::with_capacity(min)
+            }
+            (_, _) => {
+                // There isn't even a minimum size known.
+                Self::new()
+            }
+        };
+
         this.extend(iter);
+        this.shrink_to_fit();
         this
     }
 }
@@ -269,11 +287,13 @@ impl<'a, T: 'a + Copy + Eq> Extend<&'a T> for Set<T> {
     }
 }
 
-impl<V, T: Into<Vec<V>>> From<T> for Set<V> {
+impl<V: Eq, T: Into<Vec<V>>> From<T> for Set<V> {
     fn from(values: T) -> Self {
-        Self {
-            backing: values.into(),
-        }
+        let values = values.into();
+        let mut map = Self::with_capacity(values.len());
+        map.extend(values);
+        map.shrink_to_fit();
+        map
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -23,11 +23,19 @@ use core::{
 /// assert!(set3.insert(3));
 /// assert_eq!(&set2 - &set1, set3);
 /// ```
-#[derive(Clone, Default, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Set<T> {
     backing: Vec<T>,
+}
+
+impl<T> Default for Set<T> {
+    fn default() -> Self {
+        Self {
+            backing: Vec::default(),
+        }
+    }
 }
 
 impl<T: Eq> Set<T> {
@@ -691,5 +699,15 @@ mod test_set {
         assert!(set.contains(&2));
         assert!(set.contains(&4));
         assert!(set.contains(&6));
+    }
+
+    /// Ensures that, like `Vec`, `Default` works for `Set` even when its value
+    /// type does not implement `Default`.
+    #[test]
+    fn test_default() {
+        struct NoDefault;
+
+        let _: Vec<NoDefault> = Default::default();
+        let _: Set<NoDefault> = Default::default();
     }
 }


### PR DESCRIPTION
I have a project where I'm currently using `BTreeMap`, and I have a struct field where I store its `Iterator`. I would like to use this crate, but I'm having some difficulty doing that with the `impl Iterator` returned by the `map_vec::Map::iter()`. It's made more difficult by the fact that I need to be able to clone the `Iterator`. Returning a concrete type for the `Iterator` greatly simplifies things.

Also fixed clippy warnings and updated dependencies.