### PR TITLE
Updated lints for Rust 1.81

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "map_vec"
-version = "0.5.0"
+version = "0.6.0"
+rust-version = "1.61.0"
 license = "MIT OR Apache-2.0"
 authors = ["Nick Hynes <nhynes@nhynes.com>"]
 repository = "https://github.com/nhynes/map_vec"
@@ -9,9 +10,10 @@ readme = "README.md"
 categories = ["data-structures", "embedded", "no-std"]
 edition = "2021"
 keywords = ["vec", "map", "set"]
+exclude = [".vscode", "check.sh"]
 
 [dependencies]
-serde = { version = "1", optional = true, features = ["derive"] }
+serde = { version = "1", optional = true, default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
 pretty_assertions = "1"
@@ -19,5 +21,10 @@ serde_json = "1"
 rand = "0.8"
 
 [features]
-default = ["serde"]
+default = []
+serde = ["dep:serde"]
+# This feature can only be used with the `nightly` toolchain.
 nightly = []
+
+[package.metadata.docs.rs]
+all-features = true

--- a/README.md
+++ b/README.md
@@ -1,45 +1,40 @@
 # map_vec
 
-**The Map and Set APIs backed by Vecs**
+## The Map and Set APIs backed by Vecs
 
 [`map_vec::Map`](https://docs.rs/map_vec/latest/map_vec/map/struct.Map.html) is a data structure with the interface of [`HashMap`](https://doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html).
 Similarly [`map_vec::Set`](https://docs.rs/map_vec/latest/map_vec/set/struct.Set.html) is a data structure with the interface of [`HashSet`](https://doc.rust-lang.org/std/collections/hash_set/struct.HashSet.html).
 
 Vector-backed maps and sets are primarily useful when you care about constant factors or prefer determinism to speed.
-Please refer to the docs for HashMap and HashSet for details on and examples of using the Map/Set API.
+Please refer to the docs for [`HashMap`](https://doc.rust-lang.org/std/collections/hash_map/struct.HashMap.html) and [`HashSet`](https://doc.rust-lang.org/std/collections/hash_set/struct.HashSet.html) for details on and examples of using the `Map`/`Set` API.
 
 ## Optional features
 
 Declare the `map_vec` dependency with `serde` support to get `Serialize` and `Deserialize` on `Map` and `Set`.
-This requires a `std` environment, though.
 
 ```toml
-map_vec = { version = "0.3", features = ["serde"] }
+map_vec = { version = "0.6", features = ["serde"] }
 ```
 
 ## Map Example
 
 ```rust
-fn main() {
-  let mut map = map_vec::Map::new();
-  map.insert("hello".to_string(), "world".to_string());
-  map.entry("hello".to_string()).and_modify(|mut v| v.push_str("!"));
-  assert_eq!(map.get("hello").map(String::as_str), Some("world!"))
-}
+let mut map = map_vec::Map::new();
+map.insert("hello".to_string(), "world".to_string());
+map.entry("hello".to_string()).and_modify(|mut v| v.push_str("!"));
+assert_eq!(map.get("hello").map(String::as_str), Some("world!"))
 ```
 
 ## Set Example
 
 ```rust
-fn main() {
-  let mut set1 = map_vec::Set::new();
-  let mut set2 = map_vec::Set::new();
-  set1.insert(1);
-  set1.insert(2);
-  set2.insert(2);
-  set2.insert(3);
-  let mut set3 = map_vec::Set::with_capacity(1);
-  assert!(set3.insert(3));
-  assert_eq!(&set2 - &set1, set3);
-}
+let mut set1 = map_vec::Set::new();
+let mut set2 = map_vec::Set::new();
+set1.insert(1);
+set1.insert(2);
+set2.insert(2);
+set2.insert(3);
+let mut set3 = map_vec::Set::with_capacity(1);
+assert!(set3.insert(3));
+assert_eq!(&set2 - &set1, set3);
 ```

--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# The checks with the `aarch64-unknown-none` target ensure that the library can 
+# target a `no_std` environment.
+
+set -x
+
+# Lint
+cargo clippy -- -Dwarnings && \
+cargo clippy --no-default-features -- -Dwarnings && \
+cargo clippy --no-default-features --features serde -- -Dwarnings && \
+cargo +nightly clippy --all-features && \
+
+cargo clippy --tests -- -Dwarnings && \
+cargo clippy --tests --no-default-features -- -Dwarnings && \
+cargo clippy --tests --no-default-features --features serde -- -Dwarnings && \
+cargo +nightly clippy --tests --all-features && \
+
+# Check against a target that does _not_ support `std` to ensure it doesn't 
+# creep in from a dependency or anything.
+cargo clippy --target aarch64-unknown-none -- -Dwarnings && \
+cargo clippy --target aarch64-unknown-none --no-default-features -- -Dwarnings && \
+cargo clippy --target aarch64-unknown-none --no-default-features --features serde -- -Dwarnings && \
+cargo +nightly clippy --target aarch64-unknown-none --features serde && \
+
+# Tests
+cargo test && \
+cargo test --no-default-features && \
+cargo test --no-default-features --features serde && \
+cargo +nightly test --all-features && \
+
+# Documentation
+cargo +nightly doc --all-features && \
+
+# Publishable?
+cargo publish --dry-run -v --allow-dirty
+
+set +x

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,15 @@
-//! # map_vec: Map and Set APIs backed by `Vec`s.
-
-#![cfg_attr(not(test), no_std)]
-#![cfg_attr(feature = "nightly", feature(drain_filter, try_reserve_kind))]
+#![doc = include_str!("../README.md")]
+#![cfg_attr(not(any(test, doc)), no_std)]
+#![cfg_attr(feature = "nightly", feature(trusted_len, try_reserve_kind))]
+#![cfg_attr(any(docsrs, feature = "nightly"), feature(doc_cfg))]
 
 extern crate alloc;
 
 pub mod map;
 pub mod set;
 
+#[doc(inline)]
 pub use map::Map;
-pub use set::Set;
 
-#[doc = include_str!("../README.md")]
-#[cfg(doctest)]
-struct ReadmeDoctests;
+#[doc(inline)]
+pub use set::Set;


### PR DESCRIPTION
* Fixed default features to not include `serde`
* Using `serde` no longer adds `std` (this was accidentally added in a recent release)
* Fixed lints
* Updated unstable features
* Documentation tweaks